### PR TITLE
style: refresh ui component styling and demo

### DIFF
--- a/components/ui/display/Badge.tsx
+++ b/components/ui/display/Badge.tsx
@@ -1,6 +1,9 @@
+import { useMemo } from "react"
 import type { ReactNode } from "react"
 
 import { cn } from "../support/cn"
+import { withAlpha } from "../support/color"
+import { useTheme } from "../support/ThemeProvider"
 
 type BadgeTone = "default" | "primary" | "info" | "success" | "warning" | "danger"
 
@@ -12,39 +15,6 @@ interface BadgeProps {
   size?: BadgeSize
   icon?: ReactNode
   className?: string
-}
-
-const toneColorMap: Record<BadgeTone, { background: string; text: string; border: string }> = {
-  default: {
-    background: "rgba(12,17,29,0.06)",
-    text: "var(--ui-text)",
-    border: "var(--ui-border)"
-  },
-  primary: {
-    background: "rgba(11,99,255,0.12)",
-    text: "#0b63ff",
-    border: "rgba(11,99,255,0.4)"
-  },
-  info: {
-    background: "rgba(36,98,181,0.12)",
-    text: "var(--ui-info)",
-    border: "rgba(36,98,181,0.4)"
-  },
-  success: {
-    background: "rgba(26,127,55,0.12)",
-    text: "var(--ui-success)",
-    border: "rgba(26,127,55,0.4)"
-  },
-  warning: {
-    background: "rgba(178,94,13,0.12)",
-    text: "var(--ui-warning)",
-    border: "rgba(178,94,13,0.4)"
-  },
-  danger: {
-    background: "rgba(180,35,24,0.12)",
-    text: "var(--ui-danger)",
-    border: "rgba(180,35,24,0.4)"
-  }
 }
 
 const sizeClassMap: Record<BadgeSize, string> = {
@@ -59,7 +29,44 @@ export const Badge = ({
   icon,
   className
 }: BadgeProps) => {
-  const palette = toneColorMap[tone]
+  const theme = useTheme()
+
+  const paletteMap = useMemo(() => {
+    return {
+      default: {
+        background: withAlpha(theme.colors.text, 0.06),
+        text: theme.colors.text,
+        border: theme.colors.border
+      },
+      primary: {
+        background: withAlpha(theme.colors.primary, 0.16),
+        text: theme.colors.primary,
+        border: withAlpha(theme.colors.primary, 0.4)
+      },
+      info: {
+        background: withAlpha(theme.colors.info, 0.16),
+        text: theme.colors.info,
+        border: withAlpha(theme.colors.info, 0.4)
+      },
+      success: {
+        background: withAlpha(theme.colors.success, 0.16),
+        text: theme.colors.success,
+        border: withAlpha(theme.colors.success, 0.4)
+      },
+      warning: {
+        background: withAlpha(theme.colors.warning, 0.16),
+        text: theme.colors.warning,
+        border: withAlpha(theme.colors.warning, 0.4)
+      },
+      danger: {
+        background: withAlpha(theme.colors.danger, 0.16),
+        text: theme.colors.danger,
+        border: withAlpha(theme.colors.danger, 0.4)
+      }
+    } satisfies Record<BadgeTone, { background: string; text: string; border: string }>
+  }, [theme])
+
+  const palette = paletteMap[tone]
 
   return (
     <span

--- a/components/ui/display/MediaPreview.tsx
+++ b/components/ui/display/MediaPreview.tsx
@@ -1,8 +1,10 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import type { ReactNode } from "react"
 
 import { Icon } from "./Icon"
 import { cn } from "../support/cn"
+import { readableTextColor, withAlpha } from "../support/color"
+import { useTheme } from "../support/ThemeProvider"
 
 interface MediaPreviewProps {
   src: string
@@ -24,6 +26,13 @@ export const MediaPreview = ({
   removable = true
 }: MediaPreviewProps) => {
   const [loaded, setLoaded] = useState(false)
+  const theme = useTheme()
+  const backgroundTint = withAlpha(theme.colors.text, 0.08)
+  const overlayBackground = withAlpha(theme.colors.text, 0.78)
+  const overlayColor = useMemo(
+    () => readableTextColor(overlayBackground, theme.colors.text, theme.colors.surface),
+    [overlayBackground, theme.colors.surface, theme.colors.text]
+  )
 
   return (
     <div
@@ -31,8 +40,8 @@ export const MediaPreview = ({
       style={{
         width: `${size}px`,
         height: `${size}px`,
-        borderColor: "var(--ui-border)",
-        backgroundColor: "rgba(12,17,29,0.06)"
+        borderColor: theme.colors.border,
+        backgroundColor: backgroundTint
       }}
     >
       <img
@@ -46,9 +55,9 @@ export const MediaPreview = ({
         <div
           className="absolute inset-x-0 bottom-0 border-t px-2 py-1 text-[10px] uppercase tracking-[0.12em]"
           style={{
-            borderColor: "var(--ui-border)",
-            backgroundColor: "rgba(12,17,29,0.75)",
-            color: "#ffffff"
+            borderColor: theme.colors.border,
+            backgroundColor: overlayBackground,
+            color: overlayColor
           }}
         >
           {overlay}
@@ -59,9 +68,9 @@ export const MediaPreview = ({
           type="button"
           className="absolute right-1 top-1 border px-1 py-0 text-[10px] uppercase tracking-[0.12em]"
           style={{
-            borderColor: "var(--ui-border)",
-            backgroundColor: "var(--ui-surface)",
-            color: "var(--ui-text)"
+            borderColor: theme.colors.border,
+            backgroundColor: theme.colors.surface,
+            color: theme.colors.text
           }}
           onClick={onRemove}
         >

--- a/components/ui/display/RichTextViewer.tsx
+++ b/components/ui/display/RichTextViewer.tsx
@@ -15,9 +15,18 @@ const parseMarkdown = (content: string): string => {
     .replace(/^### (.*$)/gm, '<h3 class="mb-2 mt-3 text-base font-semibold uppercase tracking-[0.06em]" style="color: var(--ui-text)">$1</h3>')
     .replace(/^> (.*$)/gm, '<blockquote class="mb-4 border-l-2 pl-3 text-sm" style="border-color: var(--ui-border-strong); color: var(--ui-text-muted)">$1</blockquote>')
     .replace(/^\- (.*$)/gm, '<li class="mb-1" style="color: var(--ui-text)">$1</li>')
-    .replace(/`([^`]+)`/g, '<code class="rounded-none border px-1 text-xs" style="background-color: rgba(12,17,29,0.04); border-color: var(--ui-border); font-family: var(--ui-font-mono); color: var(--ui-text)">$1</code>')
-    .replace(/```(\w+)?\n([\s\S]*?)```/g, '<pre class="mb-3 overflow-auto border p-3 text-xs" style="background-color: rgba(12,17,29,0.06); border-color: var(--ui-border); font-family: var(--ui-font-mono); color: var(--ui-text)"><code>$2</code></pre>')
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="underline decoration-[rgba(11,99,255,0.4)] decoration-2 underline-offset-2" style="color: #0b63ff" target="_blank" rel="noreferrer">$1</a>')
+    .replace(
+      /`([^`]+)`/g,
+      '<code class="rounded-none border px-1 text-xs" style="background-color: color-mix(in srgb, var(--ui-text) 8%, transparent); border-color: var(--ui-border); font-family: var(--ui-font-mono); color: var(--ui-text)">$1</code>'
+    )
+    .replace(
+      /```(\w+)?\n([\s\S]*?)```/g,
+      '<pre class="mb-3 overflow-auto border p-3 text-xs" style="background-color: color-mix(in srgb, var(--ui-text) 6%, transparent); border-color: var(--ui-border); font-family: var(--ui-font-mono); color: var(--ui-text)"><code>$2</code></pre>'
+    )
+    .replace(
+      /\[([^\]]+)\]\(([^)]+)\)/g,
+      '<a href="$2" class="underline" style="color: var(--ui-primary); text-decoration-color: color-mix(in srgb, var(--ui-primary) 45%, transparent); text-decoration-thickness: 2px; text-underline-offset: 4px" target="_blank" rel="noreferrer">$1</a>'
+    )
     .replace(/\n\n/g, '</p><p class="mb-2 leading-relaxed text-sm last:mb-0" style="color: var(--ui-text)">')
     .replace(/\n/g, '<br>')
 }
@@ -54,7 +63,7 @@ const components_unused = {
         <code
           className="rounded-none border px-1 text-xs"
           style={{
-            backgroundColor: "rgba(12,17,29,0.04)",
+            backgroundColor: "color-mix(in srgb, var(--ui-text) 8%, transparent)",
             borderColor: "var(--ui-border)",
             fontFamily: "var(--ui-font-mono)",
             color: "var(--ui-text)"
@@ -69,7 +78,7 @@ const components_unused = {
       <pre
         className="mb-3 overflow-auto border p-3 text-xs"
         style={{
-          backgroundColor: "rgba(12,17,29,0.06)",
+          backgroundColor: "color-mix(in srgb, var(--ui-text) 6%, transparent)",
           borderColor: "var(--ui-border)",
           fontFamily: "var(--ui-font-mono)",
           color: "var(--ui-text)"
@@ -82,8 +91,13 @@ const components_unused = {
   a: ({ children, href }) => (
     <a
       href={href}
-      className="underline decoration-[rgba(11,99,255,0.4)] decoration-2 underline-offset-2"
-      style={{ color: "#0b63ff" }}
+      className="underline"
+      style={{
+        color: "var(--ui-primary)",
+        textDecorationColor: "color-mix(in srgb, var(--ui-primary) 45%, transparent)",
+        textDecorationThickness: "2px",
+        textUnderlineOffset: "4px"
+      }}
       target="_blank"
       rel="noreferrer"
     >

--- a/components/ui/feedback/InlineAlert.tsx
+++ b/components/ui/feedback/InlineAlert.tsx
@@ -1,6 +1,9 @@
+import { useMemo } from "react"
 import type { ReactNode } from "react"
 
 import { cn } from "../support/cn"
+import { withAlpha } from "../support/color"
+import { useTheme } from "../support/ThemeProvider"
 
 export type InlineAlertTone = "info" | "success" | "warning" | "danger"
 
@@ -12,35 +15,39 @@ interface InlineAlertProps {
   className?: string
 }
 
-const tonePalette: Record<InlineAlertTone, { background: string; border: string; title: string; description: string }> = {
-  info: {
-    background: "rgba(36,98,181,0.12)",
-    border: "rgba(36,98,181,0.4)",
-    title: "var(--ui-info)",
-    description: "var(--ui-text)"
-  },
-  success: {
-    background: "rgba(26,127,55,0.12)",
-    border: "rgba(26,127,55,0.4)",
-    title: "var(--ui-success)",
-    description: "var(--ui-text)"
-  },
-  warning: {
-    background: "rgba(178,94,13,0.12)",
-    border: "rgba(178,94,13,0.4)",
-    title: "var(--ui-warning)",
-    description: "var(--ui-text)"
-  },
-  danger: {
-    background: "rgba(180,35,24,0.12)",
-    border: "rgba(180,35,24,0.4)",
-    title: "var(--ui-danger)",
-    description: "var(--ui-text)"
-  }
-}
-
 export const InlineAlert = ({ title, description, tone = "info", action, className }: InlineAlertProps) => {
-  const palette = tonePalette[tone]
+  const theme = useTheme()
+
+  const paletteMap = useMemo(() => {
+    return {
+      info: {
+        background: withAlpha(theme.colors.info, 0.16),
+        border: withAlpha(theme.colors.info, 0.4),
+        title: theme.colors.info,
+        description: theme.colors.text
+      },
+      success: {
+        background: withAlpha(theme.colors.success, 0.16),
+        border: withAlpha(theme.colors.success, 0.4),
+        title: theme.colors.success,
+        description: theme.colors.text
+      },
+      warning: {
+        background: withAlpha(theme.colors.warning, 0.16),
+        border: withAlpha(theme.colors.warning, 0.4),
+        title: theme.colors.warning,
+        description: theme.colors.text
+      },
+      danger: {
+        background: withAlpha(theme.colors.danger, 0.16),
+        border: withAlpha(theme.colors.danger, 0.4),
+        title: theme.colors.danger,
+        description: theme.colors.text
+      }
+    } satisfies Record<InlineAlertTone, { background: string; border: string; title: string; description: string }>
+  }, [theme])
+
+  const palette = paletteMap[tone]
 
   return (
     <div

--- a/components/ui/feedback/Modal.tsx
+++ b/components/ui/feedback/Modal.tsx
@@ -3,6 +3,8 @@ import { useEffect } from "react"
 import type { CSSProperties, ReactNode } from "react"
 
 import { cn } from "../support/cn"
+import { darken, withAlpha } from "../support/color"
+import { useTheme } from "../support/ThemeProvider"
 
 interface ModalProps {
   open: boolean
@@ -30,6 +32,8 @@ const overlayRoot = () => {
 }
 
 export const Modal = ({ open, onClose, title, description, footer, children, width = 480 }: ModalProps) => {
+  const theme = useTheme()
+
   useEffect(() => {
     if (!open) {
       return
@@ -55,32 +59,33 @@ export const Modal = ({ open, onClose, title, description, footer, children, wid
   return createPortal(
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
-      style={{ backgroundColor: "rgba(12,17,29,0.52)" }}
+      style={{ backgroundColor: withAlpha(theme.colors.text, 0.58) }}
       onClick={onClose}
     >
       <div
-        className={cn("border px-6 py-4 shadow-xl")}
+        className={cn("border px-6 py-4")}
         style={{
           width: `${width}px`,
           maxWidth: "90vw",
-          backgroundColor: "var(--ui-surface)",
-          borderColor: "var(--ui-border)"
+          backgroundColor: theme.colors.surface,
+          borderColor: theme.colors.border,
+          boxShadow: "var(--ui-shadow-overlay)"
         }}
         onClick={(event) => event.stopPropagation()}
       >
         {title ? (
-          <div className="mb-2 text-lg font-semibold uppercase tracking-[0.08em]" style={{ color: "var(--ui-text)" }}>
+          <div className="mb-2 text-lg font-semibold uppercase tracking-[0.08em]" style={{ color: theme.colors.text }}>
             {title}
           </div>
         ) : null}
         {description ? (
-          <div className="mb-4 text-sm" style={{ color: "var(--ui-text-muted)" }}>
+          <div className="mb-4 text-sm" style={{ color: theme.colors.textMuted }}>
             {description}
           </div>
         ) : null}
         {children}
         {footer ? (
-          <div className="mt-6 flex items-center justify-end gap-2 border-t pt-3" style={{ borderColor: "var(--ui-border)" }}>
+          <div className="mt-6 flex items-center justify-end gap-2 border-t pt-3" style={{ borderColor: theme.colors.border }}>
             {footer}
           </div>
         ) : null}
@@ -109,6 +114,8 @@ export const MiniConfirmModal = ({
   confirmLabel = "Confirm",
   cancelLabel = "Cancel"
 }: MiniConfirmModalProps) => {
+  const theme = useTheme()
+
   const target = overlayRoot()
   if (!open || !target) {
     return null
@@ -130,17 +137,25 @@ export const MiniConfirmModal = ({
   return createPortal(
     <div style={style} className="z-50" onClick={(event) => event.stopPropagation()}>
       <div
-        className="border px-4 py-3 shadow-lg"
-        style={{ backgroundColor: "var(--ui-surface)", borderColor: "var(--ui-border)" }}
+        className="border px-4 py-3"
+        style={{
+          backgroundColor: theme.colors.surface,
+          borderColor: theme.colors.border,
+          boxShadow: "var(--ui-shadow-raised)"
+        }}
       >
-        <div className="mb-3 text-sm" style={{ color: "var(--ui-text)" }}>
+        <div className="mb-3 text-sm" style={{ color: theme.colors.text }}>
           {message}
         </div>
         <div className="flex items-center justify-end gap-2">
           <button
             type="button"
             className="border px-3 py-1 text-xs uppercase tracking-[0.12em]"
-            style={{ borderColor: "var(--ui-border)", color: "var(--ui-text-muted)", backgroundColor: "var(--ui-surface)" }}
+            style={{
+              borderColor: theme.colors.border,
+              color: theme.colors.textMuted,
+              backgroundColor: theme.colors.surface
+            }}
             onClick={onCancel}
           >
             {cancelLabel}
@@ -148,7 +163,11 @@ export const MiniConfirmModal = ({
           <button
             type="button"
             className="border px-3 py-1 text-xs uppercase tracking-[0.12em]"
-            style={{ borderColor: "#0b63ff", backgroundColor: "#0b63ff", color: "#ffffff" }}
+            style={{
+              borderColor: darken(theme.colors.primary, 0.16),
+              backgroundColor: theme.colors.primary,
+              color: theme.colors.primaryText
+            }}
             onClick={onConfirm}
           >
             {confirmLabel}

--- a/components/ui/feedback/Spinner.tsx
+++ b/components/ui/feedback/Spinner.tsx
@@ -14,10 +14,10 @@ interface SpinnerProps {
 }
 
 const toneColor: Record<SpinnerTone, string> = {
-  primary: "#0b63ff",
-  secondary: "#ff7a1a",
+  primary: "var(--ui-primary)",
+  secondary: "var(--ui-secondary)",
   neutral: "var(--ui-border-strong)",
-  danger: "#b42318"
+  danger: "var(--ui-danger)"
 }
 
 const sizeToStyle = (size: SpinnerSize): CSSProperties => {
@@ -80,9 +80,9 @@ interface ProgressIndicatorProps {
 }
 
 const progressTone: Record<NonNullable<ProgressIndicatorProps["tone"]>, string> = {
-  primary: "#0b63ff",
-  secondary: "#ff7a1a",
-  danger: "#b42318"
+  primary: "var(--ui-primary)",
+  secondary: "var(--ui-secondary)",
+  danger: "var(--ui-danger)"
 }
 
 export const ProgressIndicator = ({
@@ -100,7 +100,13 @@ export const ProgressIndicator = ({
           {!indeterminate ? <span>{Math.round(value)}%</span> : null}
         </div>
       ) : null}
-      <div className="h-2 border" style={{ borderColor: "var(--ui-border)", backgroundColor: "rgba(12,17,29,0.06)" }}>
+      <div
+        className="h-2 border"
+        style={{
+          borderColor: "var(--ui-border)",
+          backgroundColor: "color-mix(in srgb, var(--ui-text) 8%, transparent)"
+        }}
+      >
         <div
           className={cn("h-full", indeterminate ? "animate-pulse" : "")}
           style={{

--- a/components/ui/feedback/StatusBadge.tsx
+++ b/components/ui/feedback/StatusBadge.tsx
@@ -1,4 +1,8 @@
+import { useMemo } from "react"
+
 import { cn } from "../support/cn"
+import { withAlpha } from "../support/color"
+import { useTheme } from "../support/ThemeProvider"
 
 export type StatusTone = "neutral" | "info" | "success" | "warning" | "danger"
 
@@ -9,36 +13,40 @@ interface StatusBadgeProps {
   className?: string
 }
 
-const tonePalette: Record<StatusTone, { background: string; color: string; border: string }> = {
-  neutral: {
-    background: "rgba(12,17,29,0.08)",
-    color: "var(--ui-text)",
-    border: "var(--ui-border)"
-  },
-  info: {
-    background: "rgba(36,98,181,0.12)",
-    color: "var(--ui-info)",
-    border: "rgba(36,98,181,0.4)"
-  },
-  success: {
-    background: "rgba(26,127,55,0.12)",
-    color: "var(--ui-success)",
-    border: "rgba(26,127,55,0.4)"
-  },
-  warning: {
-    background: "rgba(178,94,13,0.12)",
-    color: "var(--ui-warning)",
-    border: "rgba(178,94,13,0.4)"
-  },
-  danger: {
-    background: "rgba(180,35,24,0.12)",
-    color: "var(--ui-danger)",
-    border: "rgba(180,35,24,0.4)"
-  }
-}
-
 export const StatusBadge = ({ tone = "neutral", label, pulse = false, className }: StatusBadgeProps) => {
-  const palette = tonePalette[tone]
+  const theme = useTheme()
+
+  const paletteMap = useMemo(() => {
+    return {
+      neutral: {
+        background: withAlpha(theme.colors.text, 0.08),
+        color: theme.colors.text,
+        border: theme.colors.border
+      },
+      info: {
+        background: withAlpha(theme.colors.info, 0.16),
+        color: theme.colors.info,
+        border: withAlpha(theme.colors.info, 0.4)
+      },
+      success: {
+        background: withAlpha(theme.colors.success, 0.16),
+        color: theme.colors.success,
+        border: withAlpha(theme.colors.success, 0.4)
+      },
+      warning: {
+        background: withAlpha(theme.colors.warning, 0.16),
+        color: theme.colors.warning,
+        border: withAlpha(theme.colors.warning, 0.4)
+      },
+      danger: {
+        background: withAlpha(theme.colors.danger, 0.16),
+        color: theme.colors.danger,
+        border: withAlpha(theme.colors.danger, 0.4)
+      }
+    } satisfies Record<StatusTone, { background: string; color: string; border: string }>
+  }, [theme])
+
+  const palette = paletteMap[tone]
 
   return (
     <span

--- a/components/ui/feedback/Tooltip.tsx
+++ b/components/ui/feedback/Tooltip.tsx
@@ -65,12 +65,13 @@ export const Tooltip = ({
       {children}
       {visible ? (
         <div
-          className={cn("absolute border px-3 py-1 text-xs uppercase tracking-[0.12em] shadow-lg", className)}
+          className={cn("absolute border px-3 py-1 text-xs uppercase tracking-[0.12em]", className)}
           style={{
             ...positionStyle(),
             backgroundColor: "var(--ui-surface)",
             borderColor: "var(--ui-border)",
-            color: "var(--ui-text)"
+            color: "var(--ui-text)",
+            boxShadow: "var(--ui-shadow-raised)"
           }}
           role="tooltip"
         >

--- a/components/ui/input/Button.tsx
+++ b/components/ui/input/Button.tsx
@@ -1,8 +1,9 @@
 import { forwardRef } from "react"
-import type { ButtonHTMLAttributes, ReactNode } from "react"
+import type { ButtonHTMLAttributes, CSSProperties, ReactNode } from "react"
 
 import { Spinner } from "../feedback/Spinner"
 import { cn } from "../support/cn"
+import { useTonePalettes } from "../support/palette"
 
 export type ButtonVariant = "solid" | "outline" | "ghost"
 export type ButtonTone = "primary" | "secondary" | "neutral" | "danger"
@@ -16,33 +17,6 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   iconPosition?: "left" | "right"
   loading?: boolean
   fullWidth?: boolean
-}
-
-const toneStyles: Record<ButtonTone, { background: string; hover: string; color: string; border: string }> = {
-  primary: {
-    background: "#0b63ff",
-    hover: "#094fcc",
-    color: "#ffffff",
-    border: "#094fcc"
-  },
-  secondary: {
-    background: "#ff7a1a",
-    hover: "#e46308",
-    color: "#0c111d",
-    border: "#e46308"
-  },
-  neutral: {
-    background: "rgba(12,17,29,0.08)",
-    hover: "rgba(12,17,29,0.12)",
-    color: "var(--ui-text)",
-    border: "var(--ui-border)"
-  },
-  danger: {
-    background: "#b42318",
-    hover: "#8f1d13",
-    color: "#ffffff",
-    border: "#8f1d13"
-  }
 }
 
 const sizeClassMap: Record<ButtonSize, string> = {
@@ -81,31 +55,27 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     className,
     ...props
   }, ref) => {
-    const palette = toneStyles[tone]
+    const palettes = useTonePalettes()
+    const tonePalette = palettes[tone]
+    const variantPalette =
+      variant === "solid"
+        ? tonePalette.solid
+        : variant === "outline"
+          ? tonePalette.outline
+          : tonePalette.ghost
 
-    const baseStyle = (() => {
-      if (variant === "solid") {
-        return {
-          backgroundColor: palette.background,
-          color: palette.color,
-          borderColor: palette.border
-        }
-      }
+    const style: CSSProperties & { "--btn-hover"?: string } = {
+      backgroundColor: variantPalette.background,
+      color: variantPalette.color,
+      borderColor: variantPalette.border
+    }
 
-      if (variant === "outline") {
-        return {
-          backgroundColor: "transparent",
-          color: tone === "neutral" ? palette.color : palette.background,
-          borderColor: tone === "neutral" ? palette.border : palette.background
-        }
-      }
+    if (variantPalette.hoverBackground) {
+      style["--btn-hover"] = variantPalette.hoverBackground
+    }
 
-      return {
-        backgroundColor: "transparent",
-        color: tone === "neutral" ? palette.color : palette.background,
-        borderColor: "transparent"
-      }
-    })()
+    const hoverClass =
+      !disabled && !loading && variantPalette.hoverBackground ? "hover:bg-[var(--btn-hover)]" : ""
 
     return (
       <button
@@ -114,10 +84,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           "inline-flex items-center justify-center gap-2 border uppercase tracking-[0.12em] transition-all",
           sizeClassMap[size],
           fullWidth ? "w-full" : "",
-          disabled || loading ? "cursor-not-allowed opacity-60" : "hover:translate-y-[-1px]",
+          disabled || loading ? "cursor-not-allowed opacity-60" : cn("hover:translate-y-[-1px]", hoverClass),
           className
         )}
-        style={baseStyle}
+        style={style}
         disabled={disabled || loading}
         {...props}
       >

--- a/components/ui/input/ButtonSelect.tsx
+++ b/components/ui/input/ButtonSelect.tsx
@@ -1,5 +1,9 @@
+import type { CSSProperties } from "react"
+
 import { Icon } from "../display/Icon"
 import { cn } from "../support/cn"
+import { darken, withAlpha } from "../support/color"
+import { useTheme } from "../support/ThemeProvider"
 
 interface ButtonSelectOption {
   id: string
@@ -21,22 +25,38 @@ export const ButtonSelect = ({
   onSelect,
   allowDeselect = false
 }: ButtonSelectProps) => {
+  const theme = useTheme()
+
+  const activeStyle: CSSProperties & { "--button-select-hover"?: string } = {
+    backgroundColor: theme.colors.primary,
+    color: theme.colors.primaryText,
+    borderColor: darken(theme.colors.primary, 0.16),
+    "--button-select-hover": darken(theme.colors.primary, 0.12)
+  }
+
+  const idleStyle: CSSProperties & { "--button-select-hover"?: string } = {
+    backgroundColor: theme.colors.surface,
+    color: theme.colors.text,
+    borderColor: theme.colors.border,
+    "--button-select-hover": withAlpha(theme.colors.primary, 0.16)
+  }
+
   return (
     <div className="flex items-center gap-2">
       {options.map((option) => {
         const isActive = option.id === selectedId
+        const style = isActive ? activeStyle : idleStyle
         return (
           <button
             key={option.id}
             type="button"
             title={option.tooltip ?? option.label}
             className={cn(
-              "flex h-10 w-10 items-center justify-center border text-xs uppercase tracking-[0.12em]",
-              isActive ? "bg-[#0b63ff] text-white" : "bg-transparent text-[var(--ui-text)]"
+              "flex h-10 w-10 items-center justify-center border text-xs uppercase tracking-[0.12em] transition-all",
+              "hover:translate-y-[-1px]",
+              "hover:bg-[var(--button-select-hover)]"
             )}
-            style={{
-              borderColor: isActive ? "#0b63ff" : "var(--ui-border)"
-            }}
+            style={style}
             onClick={() => {
               if (allowDeselect && isActive) {
                 onSelect("")

--- a/components/ui/input/ButtonSwitch.tsx
+++ b/components/ui/input/ButtonSwitch.tsx
@@ -1,5 +1,9 @@
+import type { CSSProperties } from "react"
+
 import { Icon } from "../display/Icon"
 import { cn } from "../support/cn"
+import { darken, withAlpha } from "../support/color"
+import { useTheme } from "../support/ThemeProvider"
 
 interface ButtonSwitchProps {
   checked: boolean
@@ -22,17 +26,33 @@ export const ButtonSwitch = ({
   tooltipOff,
   disabled = false
 }: ButtonSwitchProps) => {
+  const theme = useTheme()
+
+  const activeStyle: CSSProperties & { "--button-switch-hover"?: string } = {
+    backgroundColor: theme.colors.primary,
+    color: theme.colors.primaryText,
+    borderColor: darken(theme.colors.primary, 0.16),
+    "--button-switch-hover": darken(theme.colors.primary, 0.12)
+  }
+
+  const inactiveStyle: CSSProperties & { "--button-switch-hover"?: string } = {
+    backgroundColor: theme.colors.surface,
+    color: theme.colors.text,
+    borderColor: theme.colors.border,
+    "--button-switch-hover": withAlpha(theme.colors.primary, 0.16)
+  }
+
+  const style = checked ? activeStyle : inactiveStyle
+  const hoverClass = !disabled ? "hover:bg-[var(--button-switch-hover)]" : ""
+
   return (
     <button
       type="button"
       className={cn(
         "flex h-10 w-10 items-center justify-center border text-xs uppercase tracking-[0.12em]",
-        checked ? "bg-[#0b63ff] text-white" : "bg-transparent text-[var(--ui-text)]",
-        disabled ? "cursor-not-allowed opacity-60" : "hover:translate-y-[-1px]"
+        disabled ? "cursor-not-allowed opacity-60" : cn("hover:translate-y-[-1px]", hoverClass)
       )}
-      style={{
-        borderColor: checked ? "#0b63ff" : "var(--ui-border)"
-      }}
+      style={style}
       onClick={() => onToggle(!checked)}
       title={checked ? tooltipOn ?? label : tooltipOff ?? label}
       disabled={disabled}

--- a/components/ui/input/IconButton.tsx
+++ b/components/ui/input/IconButton.tsx
@@ -1,7 +1,8 @@
 import { forwardRef } from "react"
-import type { ButtonHTMLAttributes, ReactNode } from "react"
+import type { ButtonHTMLAttributes, CSSProperties, ReactNode } from "react"
 
 import { cn } from "../support/cn"
+import { useTonePalettes } from "../support/palette"
 
 export type IconButtonTone = "primary" | "secondary" | "neutral" | "danger"
 export type IconButtonVariant = "solid" | "ghost" | "outline"
@@ -21,33 +22,6 @@ const sizeMap: Record<IconButtonSize, string> = {
   lg: "h-12 w-12 text-lg"
 }
 
-const tonePalette: Record<IconButtonTone, { bg: string; hover: string; color: string; border: string }> = {
-  primary: {
-    bg: "#0b63ff",
-    hover: "#094fcc",
-    color: "#ffffff",
-    border: "#094fcc"
-  },
-  secondary: {
-    bg: "#ff7a1a",
-    hover: "#e46308",
-    color: "#0c111d",
-    border: "#e46308"
-  },
-  neutral: {
-    bg: "rgba(12,17,29,0.08)",
-    hover: "rgba(12,17,29,0.12)",
-    color: "var(--ui-text)",
-    border: "var(--ui-border)"
-  },
-  danger: {
-    bg: "#b42318",
-    hover: "#8f1d13",
-    color: "#ffffff",
-    border: "#8f1d13"
-  }
-}
-
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
   ({
     icon,
@@ -59,31 +33,26 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     disabled,
     ...props
   }, ref) => {
-    const palette = tonePalette[tone]
+    const palettes = useTonePalettes()
+    const tonePalette = palettes[tone]
+    const variantPalette =
+      variant === "solid"
+        ? tonePalette.solid
+        : variant === "outline"
+          ? tonePalette.outline
+          : tonePalette.ghost
 
-    const baseStyle = (() => {
-      if (variant === "solid") {
-        return {
-          backgroundColor: palette.bg,
-          color: palette.color,
-          borderColor: palette.border
-        }
-      }
+    const style: CSSProperties & { "--icon-button-hover"?: string } = {
+      backgroundColor: variantPalette.background,
+      color: variantPalette.color,
+      borderColor: variantPalette.border
+    }
 
-      if (variant === "outline") {
-        return {
-          backgroundColor: "transparent",
-          color: tone === "neutral" ? palette.color : palette.bg,
-          borderColor: tone === "neutral" ? palette.border : palette.bg
-        }
-      }
+    if (variantPalette.hoverBackground) {
+      style["--icon-button-hover"] = variantPalette.hoverBackground
+    }
 
-      return {
-        backgroundColor: "transparent",
-        color: tone === "neutral" ? palette.color : palette.bg,
-        borderColor: "transparent"
-      }
-    })()
+    const hoverClass = !disabled && variantPalette.hoverBackground ? "hover:bg-[var(--icon-button-hover)]" : ""
 
     return (
       <button
@@ -93,10 +62,10 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         className={cn(
           "inline-flex items-center justify-center border uppercase tracking-[0.12em] transition-all",
           sizeMap[size],
-          disabled ? "cursor-not-allowed opacity-60" : "hover:translate-y-[-1px]",
+          disabled ? "cursor-not-allowed opacity-60" : cn("hover:translate-y-[-1px]", hoverClass),
           className
         )}
-        style={baseStyle}
+        style={style}
         disabled={disabled}
         {...props}
       >

--- a/components/ui/input/Select.tsx
+++ b/components/ui/input/Select.tsx
@@ -40,7 +40,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           className="border px-3 py-2 text-sm outline-none"
           style={{
             backgroundColor: "var(--ui-surface)",
-            borderColor: error ? "#b42318" : "var(--ui-border)",
+            borderColor: error ? "var(--ui-danger)" : "var(--ui-border)",
             color: "var(--ui-text)",
             fontFamily: "var(--ui-font-base)"
           }}
@@ -56,7 +56,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           ))}
         </select>
         {error ? (
-          <span className="text-xs" style={{ color: "#b42318" }}>{error}</span>
+          <span className="text-xs" style={{ color: "var(--ui-danger)" }}>{error}</span>
         ) : helperText ? (
           <span className="text-xs" style={{ color: "var(--ui-text-muted)" }}>{helperText}</span>
         ) : null}
@@ -100,7 +100,7 @@ export const MultiSelect = forwardRef<HTMLSelectElement, MultiSelectProps>(
           className="border px-3 py-2 text-sm outline-none"
           style={{
             backgroundColor: "var(--ui-surface)",
-            borderColor: error ? "#b42318" : "var(--ui-border)",
+            borderColor: error ? "var(--ui-danger)" : "var(--ui-border)",
             color: "var(--ui-text)",
             fontFamily: "var(--ui-font-base)",
             minHeight: "120px"
@@ -116,7 +116,7 @@ export const MultiSelect = forwardRef<HTMLSelectElement, MultiSelectProps>(
           ))}
         </select>
         {error ? (
-          <span className="text-xs" style={{ color: "#b42318" }}>{error}</span>
+          <span className="text-xs" style={{ color: "var(--ui-danger)" }}>{error}</span>
         ) : helperText ? (
           <span className="text-xs" style={{ color: "var(--ui-text-muted)" }}>{helperText}</span>
         ) : null}
@@ -183,7 +183,7 @@ export const FloatingLabelSelect = forwardRef<HTMLSelectElement, FloatingLabelSe
         <div
           className="relative border"
           style={{
-            borderColor: error ? "#b42318" : "var(--ui-border)",
+            borderColor: error ? "var(--ui-danger)" : "var(--ui-border)",
             backgroundColor: "var(--ui-surface)"
           }}
         >
@@ -214,9 +214,9 @@ export const FloatingLabelSelect = forwardRef<HTMLSelectElement, FloatingLabelSe
                 "pointer-events-none absolute left-3 select-none uppercase tracking-[0.12em] text-xs transition-all",
                 isFocused || hasSelection ? "top-2 text-[10px]" : "top-1/2 -translate-y-1/2 text-[11px]"
               )}
-              style={{
-                color: error ? "#b42318" : "var(--ui-text-muted)"
-              }}
+            style={{
+              color: error ? "var(--ui-danger)" : "var(--ui-text-muted)"
+            }}
             >
               {label}
             </label>
@@ -229,7 +229,7 @@ export const FloatingLabelSelect = forwardRef<HTMLSelectElement, FloatingLabelSe
           </span>
         </div>
         {error ? (
-          <span className="text-xs" style={{ color: "#b42318" }}>
+          <span className="text-xs" style={{ color: "var(--ui-danger)" }}>
             {error}
           </span>
         ) : helperText ? (
@@ -324,7 +324,7 @@ export const FloatingLabelMultiSelect = forwardRef<HTMLSelectElement, FloatingLa
         <div
           className="relative border"
           style={{
-            borderColor: error ? "#b42318" : "var(--ui-border)",
+            borderColor: error ? "var(--ui-danger)" : "var(--ui-border)",
             backgroundColor: "var(--ui-surface)"
           }}
         >
@@ -356,16 +356,16 @@ export const FloatingLabelMultiSelect = forwardRef<HTMLSelectElement, FloatingLa
                 "pointer-events-none absolute left-3 select-none uppercase tracking-[0.12em] text-xs transition-all",
                 isFocused || selectedCount > 0 ? "top-2 text-[10px]" : "top-1/2 -translate-y-1/2 text-[11px]"
               )}
-              style={{
-                color: error ? "#b42318" : "var(--ui-text-muted)"
-              }}
+            style={{
+              color: error ? "var(--ui-danger)" : "var(--ui-text-muted)"
+            }}
             >
               {label}
             </label>
           ) : null}
         </div>
         {error ? (
-          <span className="text-xs" style={{ color: "#b42318" }}>
+          <span className="text-xs" style={{ color: "var(--ui-danger)" }}>
             {error}
           </span>
         ) : helperText ? (

--- a/components/ui/input/Switch.tsx
+++ b/components/ui/input/Switch.tsx
@@ -1,6 +1,8 @@
 import type { ButtonHTMLAttributes } from "react"
 
 import { cn } from "../support/cn"
+import { darken, withAlpha } from "../support/color"
+import { useTheme } from "../support/ThemeProvider"
 
 interface SwitchProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onChange"> {
   checked: boolean
@@ -21,6 +23,7 @@ export const Switch = ({
   className,
   ...props
 }: SwitchProps) => {
+  const theme = useTheme()
   const trackClass = size === "sm" ? "w-10 h-5" : "w-12 h-6"
   const knobSize = size === "sm" ? 16 : 20
   const trackPadding = 2
@@ -40,8 +43,8 @@ export const Switch = ({
       <span
         className={cn("relative border", trackClass, disabled ? "opacity-60" : "")}
         style={{
-          borderColor: checked ? "#0b63ff" : "var(--ui-border)",
-          backgroundColor: checked ? "#0b63ff" : "rgba(12,17,29,0.08)",
+          borderColor: checked ? darken(theme.colors.primary, 0.16) : theme.colors.border,
+          backgroundColor: checked ? theme.colors.primary : withAlpha(theme.colors.text, 0.12),
           borderRadius: 0
         }}
       >
@@ -51,8 +54,8 @@ export const Switch = ({
             transform: `translateX(${offset}px)`,
             width: `${knobSize}px`,
             height: `${knobSize}px`,
-            borderColor: checked ? "#0b63ff" : "var(--ui-border)",
-            backgroundColor: "#ffffff"
+            borderColor: checked ? darken(theme.colors.primary, 0.16) : theme.colors.border,
+            backgroundColor: theme.colors.surface
           }}
         />
       </span>

--- a/components/ui/input/TextField.tsx
+++ b/components/ui/input/TextField.tsx
@@ -49,7 +49,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           className="flex items-center gap-2 border px-3"
           style={{
             backgroundColor: "var(--ui-surface)",
-            borderColor: error ? "#b42318" : "var(--ui-border)"
+            borderColor: error ? "var(--ui-danger)" : "var(--ui-border)"
           }}
         >
           {prefix ? <span className="text-xs" style={{ color: "var(--ui-text-muted)" }}>{prefix}</span> : null}
@@ -69,7 +69,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           {suffix ? <span className="text-xs" style={{ color: "var(--ui-text-muted)" }}>{suffix}</span> : null}
         </div>
         {error ? (
-          <span className="text-xs" style={{ color: "#b42318" }}>
+          <span className="text-xs" style={{ color: "var(--ui-danger)" }}>
             {error}
           </span>
         ) : helperText ? (
@@ -105,7 +105,7 @@ export const FloatingLabelTextField = forwardRef<HTMLInputElement, FloatingLabel
         <div
           className="relative border"
           style={{
-            borderColor: error ? "#b42318" : "var(--ui-border)",
+            borderColor: error ? "var(--ui-danger)" : "var(--ui-border)",
             backgroundColor: "var(--ui-surface)"
           }}
         >
@@ -131,14 +131,14 @@ export const FloatingLabelTextField = forwardRef<HTMLInputElement, FloatingLabel
               "peer-focus:top-2 peer-focus:-translate-y-0 peer-focus:text-[10px]"
             )}
             style={{
-              color: error ? "#b42318" : "var(--ui-text-muted)"
+              color: error ? "var(--ui-danger)" : "var(--ui-text-muted)"
             }}
           >
             {floatingLabel}
           </label>
         </div>
         {error ? (
-          <span className="text-xs" style={{ color: "#b42318" }}>
+          <span className="text-xs" style={{ color: "var(--ui-danger)" }}>
             {error}
           </span>
         ) : helperText ? (

--- a/components/ui/input/Textarea.tsx
+++ b/components/ui/input/Textarea.tsx
@@ -59,7 +59,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           className="min-h-[96px] resize-y border px-3 py-3 text-sm outline-none"
           style={{
             backgroundColor: "var(--ui-surface)",
-            borderColor: error ? "#b42318" : "var(--ui-border)",
+            borderColor: error ? "var(--ui-danger)" : "var(--ui-border)",
             color: "var(--ui-text)",
             fontFamily: "var(--ui-font-base)"
           }}
@@ -71,7 +71,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         />
         <div className="flex items-center justify-between text-xs">
           {error ? (
-            <span style={{ color: "#b42318" }}>{error}</span>
+          <span style={{ color: "var(--ui-danger)" }}>{error}</span>
           ) : helperText ? (
             <span style={{ color: "var(--ui-text-muted)" }}>{helperText}</span>
           ) : (
@@ -190,7 +190,7 @@ export const FloatingLabelTextarea = forwardRef<HTMLTextAreaElement, FloatingLab
         <div
           className="relative border"
           style={{
-            borderColor: error ? "#b42318" : "var(--ui-border)",
+            borderColor: error ? "var(--ui-danger)" : "var(--ui-border)",
             backgroundColor: "var(--ui-surface)"
           }}
         >
@@ -223,7 +223,7 @@ export const FloatingLabelTextarea = forwardRef<HTMLTextAreaElement, FloatingLab
                 isFocused || hasValue ? "top-2 text-[10px]" : "top-1/2 -translate-y-1/2 text-[11px]"
               )}
               style={{
-                color: error ? "#b42318" : "var(--ui-text-muted)"
+                color: error ? "var(--ui-danger)" : "var(--ui-text-muted)"
               }}
             >
               {label}
@@ -232,7 +232,7 @@ export const FloatingLabelTextarea = forwardRef<HTMLTextAreaElement, FloatingLab
         </div>
         <div className="flex items-center justify-between text-xs">
           {error ? (
-            <span style={{ color: "#b42318" }}>{error}</span>
+            <span style={{ color: "var(--ui-danger)" }}>{error}</span>
           ) : helperText ? (
             <span style={{ color: "var(--ui-text-muted)" }}>{helperText}</span>
           ) : (

--- a/components/ui/layout/ScrollableArea.tsx
+++ b/components/ui/layout/ScrollableArea.tsx
@@ -97,10 +97,22 @@ export const ScrollableArea = ({
         ) : null}
       </div>
       {!isTop ? (
-        <div className="pointer-events-none absolute inset-x-0 top-0 h-6 bg-gradient-to-b from-[rgba(12,17,29,0.12)] to-transparent" />
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 h-6"
+          style={{
+            backgroundImage:
+              "linear-gradient(to bottom, color-mix(in srgb, var(--ui-text) 14%, transparent), transparent)"
+          }}
+        />
       ) : null}
       {!isBottom ? (
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-[rgba(12,17,29,0.12)] to-transparent" />
+        <div
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-6"
+          style={{
+            backgroundImage:
+              "linear-gradient(to top, color-mix(in srgb, var(--ui-text) 14%, transparent), transparent)"
+          }}
+        />
       ) : null}
       <div className="pointer-events-none absolute right-2 top-2 flex flex-col gap-2">
         {!isTop ? (

--- a/components/ui/navigation/ListNavigator.tsx
+++ b/components/ui/navigation/ListNavigator.tsx
@@ -6,6 +6,8 @@ import { Icon } from "../display/Icon"
 import { SearchInput } from "../input/SearchInput"
 import { StatusBadge } from "../feedback/StatusBadge"
 import { cn } from "../support/cn"
+import { withAlpha } from "../support/color"
+import { useTheme } from "../support/ThemeProvider"
 
 export interface ListNavigatorItem {
   id: string
@@ -40,6 +42,7 @@ export const ListNavigator = ({
   className
 }: ListNavigatorProps) => {
   const [query, setQuery] = useState("")
+  const theme = useTheme()
 
   const filtered = useMemo(() => {
     if (!query) {
@@ -53,10 +56,16 @@ export const ListNavigator = ({
     )
   }, [items, query])
 
+  const highlight = withAlpha(theme.colors.primary, 0.16)
+  const hoverTint = withAlpha(theme.colors.primary, 0.1)
+
   return (
-    <div className={cn("flex h-full flex-col border", className)} style={{ borderColor: "var(--ui-border)" }}>
+    <div
+      className={cn("flex h-full flex-col border", className)}
+      style={{ borderColor: theme.colors.border, backgroundColor: theme.colors.surface }}
+    >
       {searchable ? (
-        <div className="border-b p-3" style={{ borderColor: "var(--ui-border)" }}>
+        <div className="border-b p-3" style={{ borderColor: theme.colors.border }}>
           <SearchInput
             value={query}
             onChange={(event) => setQuery(event.target.value)}
@@ -68,13 +77,19 @@ export const ListNavigator = ({
       ) : null}
       <div className="flex-1 overflow-y-auto">
         {filtered.length === 0 ? (
-          <div className="flex h-full items-center justify-center text-sm" style={{ color: "var(--ui-text-muted)" }}>
+          <div className="flex h-full items-center justify-center text-sm" style={{ color: theme.colors.textMuted }}>
             {emptyState ?? "No items"}
           </div>
         ) : (
           <ul>
             {filtered.map((item) => {
               const isActive = item.id === activeId
+              const itemStyle = {
+                borderColor: theme.colors.border,
+                color: isActive ? theme.colors.primary : theme.colors.text,
+                backgroundColor: isActive ? highlight : "transparent",
+                "--navigator-hover": isActive ? highlight : hoverTint
+              }
               return (
                 <li key={item.id}>
                   <button
@@ -82,25 +97,28 @@ export const ListNavigator = ({
                     onClick={() => onSelect(item.id)}
                     className={cn(
                       "flex w-full items-start justify-between gap-3 border-b px-4 py-3 text-left",
-                      isActive ? "bg-[rgba(11,99,255,0.12)]" : "hover:bg-[rgba(12,17,29,0.06)]"
+                      "hover:bg-[var(--navigator-hover)]"
                     )}
-                    style={{ borderColor: "var(--ui-border)" }}
+                    style={itemStyle}
                   >
                     <div className="flex items-start gap-3">
                       {item.icon ? (
                         <Icon name={item.icon} size="md" ariaHidden />
                       ) : null}
                       <div>
-                        <div className="text-sm font-semibold uppercase tracking-[0.08em]" style={{ color: isActive ? "#0b63ff" : "var(--ui-text)" }}>
+                        <div
+                          className="text-sm font-semibold uppercase tracking-[0.08em]"
+                          style={{ color: isActive ? theme.colors.primary : theme.colors.text }}
+                        >
                           {item.title}
                         </div>
                         {item.description ? (
-                          <div className="text-xs" style={{ color: "var(--ui-text-muted)" }}>
+                          <div className="text-xs" style={{ color: theme.colors.textMuted }}>
                             {item.description}
                           </div>
                         ) : null}
                         {item.meta ? (
-                          <div className="mt-1 text-xs" style={{ color: "var(--ui-text-muted)" }}>
+                          <div className="mt-1 text-xs" style={{ color: theme.colors.textMuted }}>
                             {item.meta}
                           </div>
                         ) : null}
@@ -122,7 +140,7 @@ export const ListNavigator = ({
         )}
       </div>
       {footer ? (
-        <div className="border-t p-3" style={{ borderColor: "var(--ui-border)" }}>
+        <div className="border-t p-3" style={{ borderColor: theme.colors.border }}>
           {footer}
         </div>
       ) : null}

--- a/components/ui/navigation/Tabs.tsx
+++ b/components/ui/navigation/Tabs.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react"
 
 import { cn } from "../support/cn"
+import { withAlpha } from "../support/color"
+import { useTheme } from "../support/ThemeProvider"
 
 type TabState = "idle" | "loading" | "hasData"
 
@@ -33,18 +35,6 @@ const sizeClassMap: Record<TabSize, string> = {
   md: "px-4 py-3 text-sm"
 }
 
-const indicatorColor = (state: TabState | undefined, isActive: boolean) => {
-  if (state === "loading") {
-    return "linear-gradient(90deg, #0b63ff 0%, #ff7a1a 100%)"
-  }
-
-  if (state === "hasData" && !isActive) {
-    return "#0b63ff"
-  }
-
-  return isActive ? "#0b63ff" : "transparent"
-}
-
 export const Tabs = ({
   items,
   activeId,
@@ -55,6 +45,9 @@ export const Tabs = ({
   className
 }: TabsProps) => {
   const isVertical = orientation === "vertical"
+  const theme = useTheme()
+  const hoverTint = withAlpha(theme.colors.primary, 0.12)
+  const activeTint = withAlpha(theme.colors.primary, 0.18)
 
   return (
     <nav
@@ -63,14 +56,24 @@ export const Tabs = ({
         className
       )}
       role="tablist"
-      style={{ borderColor: "var(--ui-border)", backgroundColor: "var(--ui-surface)" }}
+      style={{ borderColor: theme.colors.border, backgroundColor: theme.colors.surface }}
       aria-orientation={orientation}
     >
       <div className={cn(isVertical ? "flex flex-col" : "flex items-stretch")}
       >
         {items.map((item) => {
           const isActive = item.id === activeId
-          const indicator = indicatorColor(item.state, isActive)
+          const indicator = (() => {
+            if (item.state === "loading") {
+              return `linear-gradient(90deg, ${theme.colors.primary} 0%, ${theme.colors.secondary} 100%)`
+            }
+
+            if (item.state === "hasData" && !isActive) {
+              return theme.colors.primary
+            }
+
+            return isActive ? theme.colors.primary : "transparent"
+          })()
 
           return (
             <button
@@ -85,17 +88,18 @@ export const Tabs = ({
                 "relative flex items-center gap-2 border-b text-left uppercase tracking-[0.08em] transition-colors",
                 stretch ? "flex-1" : "",
                 sizeClassMap[size],
-                item.disabled ? "opacity-60" : "hover:bg-[rgba(11,99,255,0.08)]"
+                item.disabled ? "opacity-60" : cn("hover:bg-[var(--tab-hover)]")
               )}
-              style={{
-                borderColor: "var(--ui-border)",
-                color: isActive ? "var(--ui-text)" : "var(--ui-text-muted)",
-                backgroundColor: isActive ? "rgba(11,99,255,0.06)" : "var(--ui-surface)"
-              }}
+                style={{
+                  borderColor: theme.colors.border,
+                  color: isActive ? theme.colors.text : theme.colors.textMuted,
+                  backgroundColor: isActive ? activeTint : theme.colors.surface,
+                  "--tab-hover": isActive ? activeTint : hoverTint
+                }}
             >
               {item.icon ? <span className="text-base">{item.icon}</span> : null}
               <span className="truncate">{item.label}</span>
-              {item.badge ? <span className="text-xs" style={{ color: "var(--ui-text-muted)" }}>{item.badge}</span> : null}
+              {item.badge ? <span className="text-xs" style={{ color: theme.colors.textMuted }}>{item.badge}</span> : null}
               <span
                 aria-hidden="true"
                 className={cn(

--- a/components/ui/support/color.ts
+++ b/components/ui/support/color.ts
@@ -1,0 +1,143 @@
+export interface RgbColor {
+  r: number
+  g: number
+  b: number
+}
+
+const clampChannel = (value: number) => {
+  return Math.min(255, Math.max(0, Math.round(value)))
+}
+
+const parseHex = (value: string): RgbColor | null => {
+  const normalized = value.trim().replace(/^#/, "")
+  if (normalized.length === 3) {
+    const r = parseInt(normalized[0] + normalized[0], 16)
+    const g = parseInt(normalized[1] + normalized[1], 16)
+    const b = parseInt(normalized[2] + normalized[2], 16)
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+      return null
+    }
+    return { r, g, b }
+  }
+
+  if (normalized.length === 6 || normalized.length === 8) {
+    const r = parseInt(normalized.slice(0, 2), 16)
+    const g = parseInt(normalized.slice(2, 4), 16)
+    const b = parseInt(normalized.slice(4, 6), 16)
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+      return null
+    }
+    return { r, g, b }
+  }
+
+  return null
+}
+
+const parseRgb = (value: string): RgbColor | null => {
+  const match = value.trim().match(/^rgba?\(([^)]+)\)$/i)
+  if (!match) {
+    return null
+  }
+
+  const parts = match[1]
+    .split(",")
+    .map((token) => token.trim())
+    .slice(0, 3)
+
+  if (parts.length !== 3) {
+    return null
+  }
+
+  const [rValue, gValue, bValue] = parts
+  const r = Number.parseFloat(rValue)
+  const g = Number.parseFloat(gValue)
+  const b = Number.parseFloat(bValue)
+
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+    return null
+  }
+
+  return {
+    r: clampChannel(r),
+    g: clampChannel(g),
+    b: clampChannel(b)
+  }
+}
+
+const parseColor = (value: string): RgbColor | null => {
+  if (!value) {
+    return null
+  }
+
+  return parseHex(value) ?? parseRgb(value)
+}
+
+const applyToChannels = (
+  color: string,
+  transform: (channel: number) => number
+): string => {
+  const rgb = parseColor(color)
+  if (!rgb) {
+    return color
+  }
+
+  const r = clampChannel(transform(rgb.r))
+  const g = clampChannel(transform(rgb.g))
+  const b = clampChannel(transform(rgb.b))
+
+  return `rgb(${r}, ${g}, ${b})`
+}
+
+export const withAlpha = (color: string, alpha: number) => {
+  const rgb = parseColor(color)
+  if (!rgb) {
+    return color
+  }
+
+  const safeAlpha = Math.min(1, Math.max(0, alpha))
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${safeAlpha})`
+}
+
+export const lighten = (color: string, amount: number) => {
+  const safeAmount = Math.min(1, Math.max(0, amount))
+  return applyToChannels(color, (channel) => channel + (255 - channel) * safeAmount)
+}
+
+export const darken = (color: string, amount: number) => {
+  const safeAmount = Math.min(1, Math.max(0, amount))
+  return applyToChannels(color, (channel) => channel * (1 - safeAmount))
+}
+
+const channelToLinear = (channel: number) => {
+  const normalized = channel / 255
+  if (normalized <= 0.03928) {
+    return normalized / 12.92
+  }
+  return ((normalized + 0.055) / 1.055) ** 2.4
+}
+
+const luminance = (color: string) => {
+  const rgb = parseColor(color)
+  if (!rgb) {
+    return 0
+  }
+
+  const r = channelToLinear(rgb.r)
+  const g = channelToLinear(rgb.g)
+  const b = channelToLinear(rgb.b)
+
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+export const readableTextColor = (
+  background: string,
+  lightFallback = "#ffffff",
+  darkFallback = "#0c111d"
+) => {
+  const value = luminance(background)
+  if (value === 0) {
+    return lightFallback
+  }
+
+  return value > 0.5 ? darkFallback : lightFallback
+}

--- a/components/ui/support/palette.ts
+++ b/components/ui/support/palette.ts
@@ -1,0 +1,115 @@
+import { useMemo } from "react"
+
+import type { ThemeTokens } from "./ThemeProvider"
+import { useTheme } from "./ThemeProvider"
+import { darken, readableTextColor, withAlpha } from "./color"
+
+export type ToneKey = "primary" | "secondary" | "neutral" | "danger"
+
+interface ToneVariantStyle {
+  background: string
+  border: string
+  color: string
+  hoverBackground: string
+}
+
+export type TonePalette = Record<"solid" | "outline" | "ghost", ToneVariantStyle>
+
+const buildPalette = (colors: ThemeTokens["colors"]): Record<ToneKey, TonePalette> => {
+  const primaryText = colors.primaryText
+  const secondaryText = colors.secondaryText ?? readableTextColor(colors.secondary)
+  const neutralHover = withAlpha(colors.text, 0.12)
+  const neutralGhost = withAlpha(colors.text, 0.08)
+  const dangerText = readableTextColor(colors.danger)
+
+  return {
+    primary: {
+      solid: {
+        background: colors.primary,
+        border: darken(colors.primary, 0.16),
+        color: primaryText,
+        hoverBackground: darken(colors.primary, 0.12)
+      },
+      outline: {
+        background: "transparent",
+        border: colors.primary,
+        color: colors.primary,
+        hoverBackground: withAlpha(colors.primary, 0.16)
+      },
+      ghost: {
+        background: "transparent",
+        border: "transparent",
+        color: colors.primary,
+        hoverBackground: withAlpha(colors.primary, 0.16)
+      }
+    },
+    secondary: {
+      solid: {
+        background: colors.secondary,
+        border: darken(colors.secondary, 0.18),
+        color: secondaryText,
+        hoverBackground: darken(colors.secondary, 0.12)
+      },
+      outline: {
+        background: "transparent",
+        border: colors.secondary,
+        color: colors.secondary,
+        hoverBackground: withAlpha(colors.secondary, 0.18)
+      },
+      ghost: {
+        background: "transparent",
+        border: "transparent",
+        color: colors.secondary,
+        hoverBackground: withAlpha(colors.secondary, 0.18)
+      }
+    },
+    neutral: {
+      solid: {
+        background: withAlpha(colors.text, 0.08),
+        border: colors.border,
+        color: colors.text,
+        hoverBackground: neutralHover
+      },
+      outline: {
+        background: "transparent",
+        border: colors.border,
+        color: colors.text,
+        hoverBackground: neutralGhost
+      },
+      ghost: {
+        background: "transparent",
+        border: "transparent",
+        color: colors.text,
+        hoverBackground: neutralGhost
+      }
+    },
+    danger: {
+      solid: {
+        background: colors.danger,
+        border: darken(colors.danger, 0.18),
+        color: dangerText,
+        hoverBackground: darken(colors.danger, 0.12)
+      },
+      outline: {
+        background: "transparent",
+        border: colors.danger,
+        color: colors.danger,
+        hoverBackground: withAlpha(colors.danger, 0.18)
+      },
+      ghost: {
+        background: "transparent",
+        border: "transparent",
+        color: colors.danger,
+        hoverBackground: withAlpha(colors.danger, 0.18)
+      }
+    }
+  }
+}
+
+export const useTonePalettes = () => {
+  const theme = useTheme()
+
+  return useMemo(() => buildPalette(theme.colors), [theme])
+}
+
+export const createTonePalette = buildPalette

--- a/tabs/ui-demo.tsx
+++ b/tabs/ui-demo.tsx
@@ -25,6 +25,7 @@ import {
   Badge,
   MediaPreview,
   Icon,
+  IconButton,
   TextField,
   FloatingLabelTextField,
   Textarea,
@@ -449,8 +450,16 @@ const DemoContent = () => {
               description="Page-level actions"
               trailing={
                 <InlineStack gap="sm">
-                  <Button variant="ghost" tone="neutral" size="sm" onClick={() => log.info("toolbar/refresh")}>Refresh</Button>
-                  <Button variant="ghost" tone="neutral" size="sm" onClick={() => log.info("toolbar/settings")}>Settings</Button>
+                  <IconButton
+                    label="Refresh content"
+                    icon={<Icon name="refresh" ariaHidden />}
+                    onClick={() => log.info("toolbar/refresh")}
+                  />
+                  <IconButton
+                    label="Open settings"
+                    icon={<Icon name="settings" ariaHidden />}
+                    onClick={() => log.info("toolbar/settings")}
+                  />
                 </InlineStack>
               }
             />
@@ -608,6 +617,14 @@ const DemoContent = () => {
               <Button variant="outline" tone="secondary" onClick={() => log.info("button/secondary")}>Secondary</Button>
               <Button tone="danger" onClick={() => log.info("button/danger")}>Danger</Button>
               <Button variant="ghost" tone="neutral" size="sm" onClick={() => log.info("icon-button/copy")}>Copy</Button>
+              <IconButton
+                variant="ghost"
+                tone="neutral"
+                size="sm"
+                label="Copy"
+                icon={<Icon name="content_copy" ariaHidden />}
+                onClick={() => log.info("icon-button/copy")}
+              />
             </InlineStack>
           </Stack>
         </Section>


### PR DESCRIPTION
## Summary
- add theme-aware color utilities and tone palettes for primary UI controls
- restyle layout, navigation, input, display, and feedback components to consume shared tokens
- refresh the ui-demo page to highlight the updated icon buttons and styling

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68cf528cba4c8330b4a0fcdb180f7b59